### PR TITLE
added get method to invokable

### DIFF
--- a/lib/invokables/invokable.dart
+++ b/lib/invokables/invokable.dart
@@ -74,10 +74,7 @@ mixin Invokable {
     return getGettableProperties(this).contains(prop);
   }
   Function? getMethod(dynamic method) {
-    Map<String, Function> rtn = this.methods();
-    if (this is HasController) {
-      rtn.addAll((this as HasController).controller.getBaseMethods());
-    }
+    Map<String, Function> rtn = getMethods(this);
     if (rtn.containsKey(method)) {
       return rtn[method];
     }

--- a/lib/invokables/invokable.dart
+++ b/lib/invokables/invokable.dart
@@ -73,6 +73,16 @@ mixin Invokable {
   bool hasGettableProperty(dynamic prop) {
     return getGettableProperties(this).contains(prop);
   }
+  Function? getMethod(dynamic method) {
+    Map<String, Function> rtn = this.methods();
+    if (this is HasController) {
+      rtn.addAll((this as HasController).controller.getBaseMethods());
+    }
+    if (rtn.containsKey(method)) {
+      return rtn[method];
+    }
+    return null;
+  }
   bool hasMethod(dynamic method) {
     return getMethods(this).containsKey(method);
   }


### PR DESCRIPTION
Added `getMethod` to fetch and call method when widget are dynamic widget.

Example:
![image](https://github.com/EnsembleUI/ensemble_ts_interpreter/assets/36638657/bc8f3b78-b59c-4104-a58e-01d7f22878b5)
Code link:
https://github.com/EnsembleUI/ensemble_chat/blob/fdee72188acddf8eebe9fd4f7239def7b380f19e/lib/ensemble_chat.dart#L327